### PR TITLE
Corrected the link to No CAPTCHA reCAPTCHA plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - [Additional Charsets](https://github.com/josheby/yourls-additional-charsets) - Define additional character sets for short URLs
 - [Advanced Reserved URLs](https://github.com/josheby/yourls-advanced-reserved-urls) - Extends the reserved word functionality, blocking short URLs containing reserved words, even if mixed case or written in leetspeak
 - [Advanced Reserved URLs](https://github.com/josheby/yourls-advanced-reserved-urls) - Extends the reserved word functionality, blocking short URLs containing reserved words, even if mixed case or written in leetspeak
-- [Admin NoCaptcha](https://github.com/armujahid/Admin-reCaptcha) - Protect logins with Google's No CAPTCHA reCAPTCHA (Google's ReCAPTCHA v2.0)
+- [Admin NoReCAPTCHA](https://github.com/amindeed/YOURLS-Admin-NoReCAPTCHA) - Protect logins with Google's No CAPTCHA reCAPTCHA (Google's ReCAPTCHA v2.0)
 - [Admin reCaptcha](https://github.com/armujahid/Admin-reCaptcha) - Spam protection for private YOURLS admin interface with reCaptcha
 - [Allow Aliases](https://github.com/adigitalife/yourls-allow-aliases) - Allow YOURLS to work with alias hostnames for the server
 - [Allow Forward Slashes in Short URLs](https://github.com/williambargent/YOURLS-Forward-Slash-In-Urls) - Just as the name says.


### PR DESCRIPTION
Hi everyone,

I've noticed both **Admin NoCaptcha** and **Admin reCaptcha** entries point to the same repository: https://github.com/armujahid/Admin-reCaptcha

So I put the correct name and link to the "No CAPTCHA reCAPTCHA" plugin as follows:

>**Admin NoReCAPTCHA**: https://github.com/amindeed/YOURLS-Admin-NoReCAPTCHA

*instead of:*
>**Admin NoCaptcha**: https://github.com/armujahid/Admin-reCaptcha
