### PR TITLE
New Plugin: Added ability to redirct by detecting device type

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@
 - [Memcached](https://github.com/alexalouit/Yourls-Memcached) - Memcached plugin for YOURLS
 - [Meta Redirect](https://github.com/pureexe/Yourls-meta-redirect) - Redirect using HTML meta tag when you prepend the short URL with an underscore (eg `http://sho.rt/_bleh`)
 - [Multi User](http://www.matbra.com/en/code/multi-user-yourls-plugin/) - Add support for multiple users
+- [Mobile Detect](https://github.com/guessi/yourls-mobile-detect) - Added ability to redirection by user's device type
 
 ### N
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
 - [Memcached](https://github.com/alexalouit/Yourls-Memcached) - Memcached plugin for YOURLS
 - [Meta Redirect](https://github.com/pureexe/Yourls-meta-redirect) - Redirect using HTML meta tag when you prepend the short URL with an underscore (eg `http://sho.rt/_bleh`)
 - [Multi User](http://www.matbra.com/en/code/multi-user-yourls-plugin/) - Add support for multiple users
-- [Mobile Detect](https://github.com/guessi/yourls-mobile-detect) - Added ability to redirection by user's device type
+- [Mobile Detect](https://github.com/guessi/yourls-mobile-detect) - Add ability to redirect by user device OS
 
 ### N
 
@@ -151,7 +151,7 @@
 
 - [Password Protection](https://github.com/GhostCyborg/yourls-password-protection) - Password protect any Short URL you want so that users are prompted for a password before redirection
 - [Phishtank](http://blog.yourls.org/2011/04/yourls-abuse-anti-spam-plugins/) - Prevent spam links using Phishtank's API
-- [Phishtank 2.0](https://github.com/joshp23/YOURLS-Phishtank-2.0) - Functiolnal rewrite of the old Phishtank plugin with more features
+- [Phishtank 2.0](https://github.com/joshp23/YOURLS-Phishtank-2.0) - Functional rewrite of the old Phishtank plugin with more features
 - [Piwik Stats](http://code.google.com/p/yourls/issues/detail?id=661) - Integrate statistics with Piwik
 - [Piwik-YOURLS](https://github.com/interfasys/piwik-yourls) - Piwik and a few other features
 - [Popular Clicks](https://github.com/miconda/yourls/tree/master/plugins/popular-clicks) - Display the top of the most clicked links during past days


### PR DESCRIPTION
# Use Case

There's an mobile device Apps promotion links

- iOS users would be redirected to Apple Store
- Android users would be redirected to Google Play Store
- Other users would be redirected to product promotion page

# Behind the Scenes

User who wants to view http(s)://yourls.domain/XYZ

* iOS users will be redirected to http(s)://yourls.domain/iosXYZ
* Android users will be redirect to: http(s)://yourls.domain/androidosXYZ
* For the rest of others, will be rediected to: http(s)://yourls.domain/XYZ

if it is failed to search iosXYZ or androidosXYZ, return "not found"

# Limitation

implementation required additional keyword with pre-defined prefix:
- iosXXXX
- androidosXXXX

the prefix comes from upstream "[Mobile-Detect](https://github.com/serbanghita/Mobile-Detect)" project

# Reference
- https://github.com/serbanghita/Mobile-Detect/blob/2.8.30/Mobile_Detect.php#L481