### PR TITLE
Removed outdated links, and improved formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,13 +283,21 @@ YOURLS supports localization: this means if a language file for YOURLS in availa
 
 ## Other devices and softwares
 
-- Mac: (Desktop URL shortening tool)[https://www.macupdate.com/app/mac/44088/yourls], (Textexpander)[http://www.chrismarquardt.com/blog.php?id=7952283233607249761]
-- Android: (aYourls)[https://play.google.com/store/apps/details?id=de.mateware.ayourls], (URLy)[https://play.google.com/store/apps/details?id=com.mndroid.apps.urly], (URL Shortener)[https://play.google.com/store/apps/details?id=de.keineantwort.android.urlshortener]
-- iOS: (ShortTail)[http://adamdehaven.com/blog/2015/05/shorttail-for-yourls-an-elegant-yourls-client-for-iphone/], (Clicklytics)[http://itunes.apple.com/us/app/clicklytics-track-clicks-on/id444008024?mt=8], (myYOURLS)[https://itunes.apple.com/us/app/myyourls/id661934890?mt=8]
-- Chrome: (Chrouls)[https://github.com/ukoms/Chrourls]
-- Firefox: (YOURLS shortener)[https://addons.mozilla.org/en-us/firefox/addon/yourls-shortener/]
-- (Tweetie 2)[http://www.eugenegordin.com/etc/how-to-use-your-custom-yourls-shortener-with-tweetie-2.html]
-- (Tweetbot)[http://2fatdads.com/2012/02/how-to-make-yourls-org-work-in-tweetbot/]
+- Mac:
+  * _None currently avaliable_
+- Android:
+  * [aYourls](https://play.google.com/store/apps/details?id=de.mateware.ayourls)
+  * [URLy](https://play.google.com/store/apps/details?id=com.mndroid.apps.urly)
+  * [URL Shortener](https://play.google.com/store/apps/details?id=de.keineantwort.android.urlshortener)
+- iOS:
+  * [ShortFox](https://itunes.apple.com/us/app/shortfox/id1412452706?ls=1&mt=8)
+  * [myYOURLS](https://itunes.apple.com/us/app/myyourls/id661934890?mt=8) (**OUTDATED**)
+- Chrome:
+  * [YOURLS](https://chrome.google.com/webstore/detail/yourls/nddaaiojgkoldnhnmkoldmkeocbooken)
+- Firefox:
+  * [YOURLS shortener](https://addons.mozilla.org/en-us/firefox/addon/yourls-shortener/)
+- [Tweetie 2](http://www.eugenegordin.com/etc/how-to-use-your-custom-yourls-shortener-with-tweetie-2.html)
+- [Tweetbot](http://2fatdads.com/2012/02/how-to-make-yourls-org-work-in-tweetbot/)
 
 ## Contribute
 


### PR DESCRIPTION
I removed the outdated links, and improved the formatting of the apps listed under 'Other devices and softwares', and fixed the issue with the markdown not being properly formatted for the URLs.

All of the apps listed under the Mac category were no longer available (or at least I couldn't find the download link), and most of the apps under the iOS category were removed from the App Store, except for one which does not work on the latest version of iOS. I also added my app (ShortFox) to the list under iOS. The chrome extension linked no longer existed, but I found a replacement on the chrome web store. 