### PR TITLE
Add Auth Manager Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 - [API Edit URL](https://github.com/timcrockford/yourls-api-edit-url) - Add an "update" action to the API to edit a URL, and a "geturl" action to get the long URL of a short URL
 - [Append Query String](https://github.com/drockney/append-qs) - Appends the query string to a long URL- as is
 - [Auth Manager](https://github.com/nicwaller/yourls-authmgr-plugin) - Assign users to roles like "Editor" and "Contributor" to limit the changes they are permitted to make (edit URLs, manage plugins...)
+- [Auth Manager Plus](https://github.com/joshp23/YOURLS-AuthMgrPlus) - Seperates user data & manages authorization with role-based access controls (RBAC) 
 
 ### B
 


### PR DESCRIPTION
This plugin merges @nicwaller's authmgr and @ianbarber's Seperate-Users plugins with (sometimes up to 5 years worth of) bug squashing, heavy code revisioning, and feature enhancement. Robust with hooks to filter data, this will integrate nicely with other plugins. I envision this as a great starting point for native user management. See the commit histories of my forks of the two plugins for a complete list of updates and enhancements.