### PR TITLE
adding OpenID Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,11 @@
 
 ### N
 
+- [No Traking Admins](https://github.com/joshp23/YOURLS-No-Tracking-Admins) - No loggin clicks for authenticated users (compatible with OIDC).
+
 ### O
+
+- [OIDC](https://github.com/joshp23/YOURLS-OIDC) - OpenID Connect authentication against a generic OpenID Connect server
 
 ### P
 


### PR DESCRIPTION
Adding 2 plugins. 1 enables OIDC authentication, the other stops admin tracking and is compatible with the OIDC plugin.