### PR TITLE
Edit link to Telegram Quickshare repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@
 
 ### T
 
-- [Telegram Quickshare](https://git.neht.xyz/ColinShark/yourls_tg-quickshare) - Quickly share a shortened URL via Telegram Messenger.
+- [Telegram Quickshare](https://github.com/ColinTheShark/YOURLS_tg-quickshare) - Quickly share a shortened URL via Telegram Messenger.
 - [Thumbnail URL image](https://github.com/prog-it/yourls-thumbnail-url) - Get the Thumbnail URL image (long URL) by adding `.i` to the end of the keyword
 - [Time-Period Clicks](https://github.com/rinogo/yourls-time-period-clicks) - A simple API plugin for reporting URL clicks in a specific time period (e.g. the last week, January 1 - February 1, etc).
 - [Time Limit Link](https://github.com/chesterrush/yourls-Time-Limit-Link) - Set a time limit for links


### PR DESCRIPTION
I've moved the plugin from my selfhosted Gitea instance to Github and updated the Link accordingly.