### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@
 
 - Android
   * [URLy](https://play.google.com/store/apps/details?id=com.mndroid.apps.urly)
-  * [URL Shortener](https://play.google.com/store/apps/details?id=de.keineantwort.android.urlshortener) // not updated in long time, won't be able to use yourls on new android versions.
   * [aYourls](https://gitlab.com/matecode/ayourls/-/tree/develop) - A dedicated app for YOURLS supporting server-side deletion (needs [API Delete](https://github.com/claytondaley/yourls-api-delete))
   
 - iOS

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@
 
 - Android
   * [URLy](https://play.google.com/store/apps/details?id=com.mndroid.apps.urly)
-  * [URL Shortener](https://play.google.com/store/apps/details?id=de.keineantwort.android.urlshortener)
-  * [URL Manager](https://play.google.com/store/apps/details?id=com.kizitonwose.urlmanager) - Integrates with other shortners as well, but allows multiple YOURLS servers. Mainly only creates links for YOURLS
+  * [URL Shortener](https://play.google.com/store/apps/details?id=de.keineantwort.android.urlshortener) // not updated in long time, won't be able to use yourls on new android versions.
   * [aYourls](https://gitlab.com/matecode/ayourls/-/tree/develop) - A dedicated app for YOURLS supporting server-side deletion (needs [API Delete](https://github.com/claytondaley/yourls-api-delete))
   
 - iOS


### PR DESCRIPTION
  * [URL Manager](https://play.google.com/store/apps/details?id=com.kizitonwose.urlmanager) - Integrates with other shorteners as well but allows multiple YOURLS servers. Mainly only creates links for YOURLS
- No longer available on play store so deleted

 * [URL Shortener](https://play.google.com/store/apps/details?id=de.keineantwort.android.urlshortener) // not updated in a long time, won't be able to use YOURLS service on new android versions.

^added a comment of possible non-compatibility as found in my own testing