### PR TITLE
Add YouTube Title Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@
 
 - [YAPCache](https://github.com/tipichris/YAPCache) - YAPCache is an APC based cache designed to reduce the database load of YOURLS and increase performance
 - [YOURS-TN](https://github.com/sgiovagnoli/YOURLS-TN) - Display thumbnails on YOURLS admin page and stats page, using thumbnail.ws
-- [YouTube Title Fix](https://github.com/joshp23/YOURLS-YouTube-title-fix) - Fetch YouTube page titles via Goole API
+- [YouTube Title Fix](https://github.com/joshp23/YOURLS-YouTube-title-fix) - Fetch YouTube page titles via Google API
 
 ### Z
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@
 
 - [YAPCache](https://github.com/tipichris/YAPCache) - YAPCache is an APC based cache designed to reduce the database load of YOURLS and increase performance
 - [YOURS-TN](https://github.com/sgiovagnoli/YOURLS-TN) - Display thumbnails on YOURLS admin page and stats page, using thumbnail.ws
+- [YouTube Title Fix](https://github.com/joshp23/YOURLS-YouTube-title-fix) - Fetch YouTube page titles via Goole API
 
 ### Z
 


### PR DESCRIPTION
- problem: YouTube titles are not reliably returned to YOURLS ([case use example](https://github.com/joshp23/YOURLS-title-refetch/issues/11))
- solution: fetch YouTube titles via Google API with this simple plugin