### PR TITLE
Add actively maintained SQLite driver for YOURLS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@
 - [Skimlinks](http://www.mattytemple.com/2010/12/yourls-plugin-skimlinks/) - Push all links through Skimlinks to automatically embed affiliate codes
 - [SMTP Contact](https://github.com/joshp23/YOURLS-SMTP-contact) - Provides a public contact page using PHPMailer for outbound mail delivery
 - [Snapshot](https://github.com/joshp23/YOURLS-Snapshot) - Visual preview plugin with image caching powered by PhantomJS.
-- [YOURLS SQLite](https://github.com/ozh/yourls-sqlite) - SQLite driver for YOURLS
+- [YOURLS SQLite](https://github.com/ozh/yourls-sqlite) - SQLite driver for YOURLS. It is now considered outdated.
+- [YOURLS SQLite](https://github.com/Flameborn/yourls-sqlite) - A fork of the original SQLite driver for YOURLS, actively maintained.
 - [Static Titles](https://github.com/softius/yourls-static-titles) - Provide two options to avoid the network traffic when retrieving URL titles.
 - [SSL for SSL](https://github.com/tipichris/ssl4ssl) - Generates SSL short links if the original link was SSL.
 - [Swap Short URL](https://github.com/ggwarpig/Yourls-Swap-Short-Url) - A plugin to have `http://sho.rt/blah` while having YOURLS installed in `http://sho.rt/yourls/`


### PR DESCRIPTION
This adds an actively maintained version of the SQLite driver.

I've kept the original version, in case anyone wishes to use it with an older YOURLS installation, as this version is not backwards compatible.