### PR TITLE
add tutorial video

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Make YOURLS work with other platforms, programming languages or tools.
 
 - [YOURLS with Tweetie 2](http://www.eugenegordin.com/etc/how-to-use-your-custom-yourls-shortener-with-tweetie-2.html)
 - [YOURLS with Tweetbot](https://2fatdads.com/2012/02/how-to-make-yourls-org-work-in-tweetbot/)
-
+- [Getting Started with YOURLS](https://youtu.be/9L8HtB6vZdQ) (includes API examples with Keyboard Maestro)
 
 ## Showcases [⇪](#readme)
 

--- a/README.md
+++ b/README.md
@@ -434,9 +434,9 @@ Make YOURLS work with other platforms, programming languages or tools.
 
 ### Other tutorials [⇡](#guides--tutorials-)
 
+- [Getting Started with YOURLS](https://youtu.be/9L8HtB6vZdQ) - a video presentation that includes API examples with Keyboard Maestro
 - [YOURLS with Tweetie 2](http://www.eugenegordin.com/etc/how-to-use-your-custom-yourls-shortener-with-tweetie-2.html)
 - [YOURLS with Tweetbot](https://2fatdads.com/2012/02/how-to-make-yourls-org-work-in-tweetbot/)
-- [Getting Started with YOURLS](https://youtu.be/9L8HtB6vZdQ) (includes API examples with Keyboard Maestro)
 
 ## Showcases [⇪](#readme)
 


### PR DESCRIPTION
adds link to Getting Started video that includes Automator/Keyboard Maestro shortcuts for replacing URLs in text on macOS.