### PR TITLE
Add Notifier plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 
 - [No Traking Admins](https://github.com/joshp23/YOURLS-No-Tracking-Admins) - No loggin clicks for authenticated users (compatible with OIDC).
 - [No Version Check](https://github.com/YOURLS/YOURLS/issues/2851) ☑️ - Stop YOURLS from checking if a new release is available.
+- [Notifier](https://github.com/SosthenG/yourls-notifier) - Sends notifications when actions occurs, like creating a new shortened url.
 
 [⬆️ Go to section](#plugins)
 


### PR DESCRIPTION
Only supports Discord notification and when a new link is added for now.