### PR TITLE
Added 'Fancy Animals Short Urls' to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 ### F
 
 - [Fallback URL](https://github.com/ozh/yourls-fallback-url/) - Redirect to a custom URL when the short URL does not exist.
-- [Fancy Animals Short Urls](https://github.com/cfultz/Fancy-Animal-Short-Urls) - Plugin to create cool short URLS like https://short.rip/SwiftCrimsonBullfrog
+- [Fancy Animals Short Urls](https://github.com/cfultz/Fancy-Animal-Short-Urls) - Plugin to create cool short URLS like `https://short.rip/SwiftCrimsonBullfrog`
 - [Favicon](https://github.com/YOURLS/yourls-favicon/) ☑️ - Properly displayed favicon in all cases (home screen on iOS, Android, Chrome, Safari...).
 - [Filter Code](https://github.com/ShredCode/YOURLS-filter-code) - Allow to select 3XX Status Code to return per keyword.
 - [Fix long URLs](https://github.com/adigitalife/yourls-fix-long-url) - Fix long URLs that contain %20 and other similar encodings.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 ### F
 
 - [Fallback URL](https://github.com/ozh/yourls-fallback-url/) - Redirect to a custom URL when the short URL does not exist.
+- [Fancy Animals Short Urls](https://github.com/cfultz/Fancy-Animal-Short-Urls) - Plugin to create cool short URLS like https://short.rip/SwiftCrimsonBullfrog
 - [Favicon](https://github.com/YOURLS/yourls-favicon/) ☑️ - Properly displayed favicon in all cases (home screen on iOS, Android, Chrome, Safari...).
 - [Filter Code](https://github.com/ShredCode/YOURLS-filter-code) - Allow to select 3XX Status Code to return per keyword.
 - [Fix long URLs](https://github.com/adigitalife/yourls-fix-long-url) - Fix long URLs that contain %20 and other similar encodings.


### PR DESCRIPTION
Added 'Fancy Animals Short Urls' to the README.md. I believe it's in the correct alphabetical order. It's a fork/modification of Ozh's Word Based Short Url modified to use three word lists Adjective, Color, Animal to create URL's like https://short.rip/SwiftCrimsonBullfrog