### PR TITLE
add version tag badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,8 @@ YOURLS supports localization: this means if a language file for YOURLS in availa
 - [Polish](https://github.com/tomslominski/YOURLS-pl_PL) (`pl_PL`)
 - [Portuguese](https://github.com/oscarmarcelo/YOURLS-pt_PT) (`pt_PT`)
 - [Russian](https://github.com/nsauk/YOURLS-ru_RU) (`ru_RU`)
-- [Simplified Chinese](https://github.com/taozhiyu/yourls-translation-zh_CN) (`zh_CN`)
+- [Simplified Chinese](https://github.com/taozhiyu/yourls-translation-zh_CN) (`zh_CN`) [![current version](https://img.shields.io/github/v/release/taozhiyu/yourls-translation-zh_CN?include_prereleases&display_name=release&style=flat-square&logo=github)](https://github.com/taozhiyu/yourls-translation-zh_CN/releases)
+
 - [Slovak](https://github.com/filyph/YOURLS-sk_SK) (`sk_SK`)
 - [Spanish](https://github.com/kralizeck/YOURLS-es_ES) (`es_ES`)
 - [Telugu](https://github.com/kalyan-gupta/YOURLS_Telugu_Translation) (`te_IN`)


### PR DESCRIPTION
Hi there! I wanted to share that I've noticed https://github.com/YOURLS/YOURLS.pot/pull/41 has released a new dev version. I've proactively updated the translation files to align with the latest release.

To improve project visibility and user experience, may I suggest adding a version compatibility badge to the repository? This could be implemented using Shields.io or similar service to dynamically display the supported YOURLS version. Such a badge would: 
1. Provide immediate version awareness for visitors
2. Reduce maintenance overhead by automating version tracking
3. Increase transparency for potential contributors

I originally planned to add versioning to each translation repository, but I found that they don’t use tags or releases effectively. Adding a badge would make it easier for others who are willing to update the translations.


The badge could follow this format:
![current version](https://img.shields.io/github/v/release/taozhiyu/yourls-translation-zh_cn?include_prereleases&display_name=release&style=flat-square&logo=github)
`https://img.shields.io/github/v/release/USER/REPO?include_prereleases&display_name=release&style=flat-square&logo=github`

![image](https://github.com/user-attachments/assets/b531670e-ba78-4d2b-a60d-d9dc8349fd8f)
↑↑ See that? It's very clear.