### PR TITLE
Add Plugin Status API plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Jump to [0-9](#0-9) | [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) 
 - [Phishtank](https://blog.yourls.org/2011/04/yourls-abuse-anti-spam-plugins/) - Prevent spam links using Phishtank's API.
 - [Phishtank 2.0](https://github.com/joshp23/YOURLS-Phishtank-2.0) - Functional rewrite of the old Phishtank plugin with more features.
 - [Piwik-YOURLS](https://github.com/interfasys/piwik-yourls) - Piwik and a few other features.
+- [Plugin Status API](https://https://github.com/graham55/yourls-plugin-status-api) - Adds API action to list enabled plugins and their status with filtering and health checks.
 - [Popular Clicks](https://github.com/miconda/yourls/tree/master/plugins/popular-clicks) - Display the top of the most clicked links during past days.
 - [Popular Clicks Extended](https://github.com/vaughany/yourls-popular-clicks-extended) - Shows which short links get clicked the most during a specific time frame.
 - [Popular Links](https://github.com/laaabaseball/Yourls-Popular-Links) - Adds an admin page that displays your shortener's most popular links.


### PR DESCRIPTION
Add Plugin Status API plugin
- [Plugin Status API](https://github.com/graham55/yourls-plugin-status-api) - Adds API endpoint to query plugin status, metadata, and health information with filtering capabilities.